### PR TITLE
Update Imgix token param to secure_url_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ S3_ACCESS_KEY_ID="..."
 S3_SECRET_ACCESS_KEY="..."
 S3_REGION="..."
 S3_BUCKET="..."
+S3_PREFIX="..."
 ```
 
 Afterwards you can run the tests:

--- a/lib/shrine/storage/imgix.rb
+++ b/lib/shrine/storage/imgix.rb
@@ -15,7 +15,7 @@ class Shrine
       # reader for the token.
       def initialize(storage:, **options)
         @client = ::Imgix::Client.new(options)
-        @token = options[:token]
+        @token = options[:secure_url_token]
         @storage = storage
       end
 

--- a/shrine-imgix.gemspec
+++ b/shrine-imgix.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_path = "lib"
 
   gem.add_dependency "shrine", "~> 2.0"
-  gem.add_dependency "imgix"
+  gem.add_dependency "imgix", "~> 1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"

--- a/test/imgix_test.rb
+++ b/test/imgix_test.rb
@@ -5,9 +5,9 @@ require "down"
 
 describe Shrine::Storage::Imgix do
   def imgix(options = {})
-    options[:storage] ||= s3
-    options[:host]    ||= ENV.fetch("IMGIX_HOST")
-    options[:token]   ||= ENV.fetch("IMGIX_API_KEY")
+    options[:storage]          ||= s3
+    options[:host]             ||= ENV.fetch("IMGIX_HOST")
+    options[:secure_url_token] ||= ENV.fetch("IMGIX_API_KEY")
 
     Shrine::Storage::Imgix.new(options)
   end


### PR DESCRIPTION
Thank you for all your great work on Shrine and related libraries 🙏 

This update reflects a change in the Imgix client `token` param. [It was updated to `secure_url_token`](https://github.com/imgix/imgix-rb/blob/f4b2822646601506081afcd5164169900d15b416/CHANGELOG.md#100---december-9-2015).
