### PR TITLE
api_key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ s3 = Shrine::Storage::S3.new(**s3_options)
 imgix = Shrine::Storage::Imgix.new(
   storage: s3,
   host: "my-subdomain.imgix.net",
-  token: "abc123",
+  secure_url_token: "abc123",
+  imgix_api_key: "xzy123",
 )
 
 Shrine.storages[:store] = imgix
@@ -54,6 +55,7 @@ appropriate credentials:
 
 ```sh
 # .env
+IMGIX_SECURE_URL_TOKEN="..."
 IMGIX_API_KEY="..."
 IMGIX_HOST="..."
 S3_ACCESS_KEY_ID="..."

--- a/lib/shrine/storage/imgix.rb
+++ b/lib/shrine/storage/imgix.rb
@@ -15,7 +15,7 @@ class Shrine
       # reader for the token.
       def initialize(storage:, **options)
         @client = ::Imgix::Client.new(options)
-        @token = options[:secure_url_token]
+        @api_key = options[:api_key]
         @storage = storage
       end
 
@@ -51,7 +51,7 @@ class Shrine
       # Removes the file from Imgix, along with the generated versions.
       def purge(id)
         uri = URI.parse(PURGE_URL)
-        uri.user = @token
+        uri.user = @api_key
 
         post(uri, "url" => url(id))
       end

--- a/test/imgix_test.rb
+++ b/test/imgix_test.rb
@@ -7,7 +7,8 @@ describe Shrine::Storage::Imgix do
   def imgix(options = {})
     options[:storage]          ||= s3
     options[:host]             ||= ENV.fetch("IMGIX_HOST")
-    options[:secure_url_token] ||= ENV.fetch("IMGIX_API_KEY")
+    options[:api_key]          ||= ENV.fetch("IMGIX_API_KEY")
+    options[:secure_url_token] ||= ENV.fetch("IMGIX_SECURE_URL_TOKEN")
 
     Shrine::Storage::Imgix.new(options)
   end


### PR DESCRIPTION
Currently a `secure_url_token` is passed in as an argument to the constructor. This token is also used to authenticate purging requests.

This isn't right as the `secure_url_token` can only be used to [sign secure image URLs](https://docs.imgix.com/setup/securing-images). Purge requests should [authenticate with an user account API Key](https://docs.imgix.com/setup/purging-images) (see the section about purging with CURL).

This pull requests implements an `api_key` parameter which will be used to authenticate purge requests.

NOTE: I find it odd that [the purging test works for you](https://github.com/janko-m/shrine-imgix/pull/1#issuecomment-245829343). These were causing 500 errors for me and were resolved when I started using the correct API Key.
