### PR TITLE
include storage prefix when generating url

### DIFF
--- a/lib/shrine/storage/imgix.rb
+++ b/lib/shrine/storage/imgix.rb
@@ -65,7 +65,7 @@ class Shrine
       #
       # [reference]: https://www.imgix.com/docs/reference
       def url(id, **options)
-        client.path(id).to_url(**options)
+        client.path([@storage.prefix, id].join("/")).to_url(**options)
       end
 
       # Purges the deleted file.

--- a/test/imgix_test.rb
+++ b/test/imgix_test.rb
@@ -50,6 +50,12 @@ describe Shrine::Storage::Imgix do
 
       assert_equal "image/jpeg", tempfile.content_type
     end
+
+    it "includes the storage prefix" do
+      url = @imgix.url("image.jpg", w: 150)
+
+      assert_includes url, ENV.fetch("S3_PREFIX")
+    end
   end
 
   describe "#presign" do


### PR DESCRIPTION
It looks like the imgix storage wasn't include the prefix when generating an URL.

Also see: https://groups.google.com/forum/#!topic/ruby-shrine/KvuDyC1oSiM

I used `[@storage.prefix, id].join("/"))` to generate the path. That seems to do the trick, but I'm not sure it's the most elegant way of generating it?